### PR TITLE
Remove Composer from Kapow

### DIFF
--- a/kapow-setup/kapow.sh
+++ b/kapow-setup/kapow.sh
@@ -162,7 +162,7 @@ if [ $slug ]
 fi
 
 # Install All The Things(tm).
-composer create-project && bower install && npm install
+bower install && npm install
 
 # Build the project.
 grunt


### PR DESCRIPTION
We no longer need the Kapow installer to run composer.