### PR TITLE
Remove Composer from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ An example using all of the above would look like this:
 
 At [Make Do](http://www.makedo.net) (the brains behind Kapow!) we have a few extra WordPress and Front-end dependencies that are commonly used in the projects we work on.
 
-As we didn't want to make Kapow! any more opinionated than it already is out of the box, we needed to stash our alternative `composer` and `bower` manifests in a seperate repo that we've decided to call [Kapow! Extras](https://github.com/mkdo/kapow-extras) in keeping with the comic/superhero theme!
+As we didn't want to make Kapow! any more opinionated than it already is out of the box, we needed to stash our alternative `bower` manifests in a seperate repo that we've decided to call [Kapow! Extras](https://github.com/mkdo/kapow-extras).
 
 If you'd like to add *Extras* to your project, simply add the `-x` flag immediately after your invoke the `kapow.sh` script, but before you pass in any parameters. It should look like this:
 


### PR DESCRIPTION
We no longer need to reference composer in the documentation.